### PR TITLE
Changed the member leave notification

### DIFF
--- a/1984bot.py
+++ b/1984bot.py
@@ -533,7 +533,7 @@ async def viewKeys(ctx):
 
 @bot.event
 async def on_member_remove(member):
-    leaveEmbed = discord.Embed(title = 'Goodbye!', description = f'{member.mention} has left with the following roles: {member.roles}', color = discord.Color.greyple())
+    leaveEmbed = discord.Embed(title = 'Goodbye!', description = f'{member.proper} has left with the following roles: {member.roles}', color = discord.Color.greyple())
     leaveEmbed.set_author(name = member.name, icon_url = member.avatar_url)
     await logChannel.send(embed = leaveEmbed)
 


### PR DESCRIPTION
Sometimes the text of the member leave notification displays the username of the person properly, sometimes the mention string fails to format correctly. This doesn't even matter because the embed title also contains the user's name, but it annoys me just enough to want to change it.

Just make sure I didn't do it wrong, ok?